### PR TITLE
NUT-226_EnemyDeathRework

### DIFF
--- a/NutMyProblemUnity/Assets/Scripts/CommonKnughtController.cs
+++ b/NutMyProblemUnity/Assets/Scripts/CommonKnughtController.cs
@@ -183,7 +183,8 @@ public class CommonKnughtController : MonoBehaviour
             { mode = AIMode.patrol; }
         }
     }
-    private void OnDestroy()
+
+    public void CommonKnughtDeath()
     {
         if (!gm.changingScene)
         {
@@ -193,11 +194,9 @@ public class CommonKnughtController : MonoBehaviour
 
             WeaponDrop.GetComponent<Rigidbody2D>().AddForce(new Vector2(UnityEngine.Random.Range(-50f, 50f), 200));
             WeaponDrop.GetComponent<WeaponDropManager>().SetType(Weapons.Weapon.Type.Sword);
+            Destroy(this.gameObject);
         }
-
     }
-
-
 
     public void SwordAttack(directions _directions)
     {

--- a/NutMyProblemUnity/Assets/Scripts/DamageHandler.cs
+++ b/NutMyProblemUnity/Assets/Scripts/DamageHandler.cs
@@ -21,7 +21,23 @@ public class DamageHandler : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if(iHealth <= 0) Destroy(this.gameObject);
+        if (iHealth <= 0)
+        {
+            switch (this.tag)
+            {
+                case "Player":
+                    Destroy(this.gameObject);
+                    break;
+
+                case "CommonKnught":
+                        GetComponent<CommonKnughtController>().CommonKnughtDeath();
+                    break;
+
+                case "Hazardnut":
+                        GetComponent<HazardnutController>().HazardnutDeath();
+                    break;
+            }
+        }
     }
 
     public void HandleDamage(int _damage, GameObject _other)

--- a/NutMyProblemUnity/Assets/Scripts/HazardnutController.cs
+++ b/NutMyProblemUnity/Assets/Scripts/HazardnutController.cs
@@ -187,7 +187,8 @@ public class HazardnutController : MonoBehaviour
             { mode = AIMode.patrol; }
         }
     }
-    private void OnDestroy()
+
+    public void HazardnutDeath()
     {
         if (!gm.changingScene)
         {
@@ -197,8 +198,12 @@ public class HazardnutController : MonoBehaviour
 
             WeaponDrop.GetComponent<Rigidbody2D>().AddForce(new Vector2(UnityEngine.Random.Range(-50f, 50f), 200));
             WeaponDrop.GetComponent<WeaponDropManager>().SetType(Weapons.Weapon.Type.Gloves);
+            Destroy(this.gameObject);
         }
     }
+
+
+
 
     public void GlovesAttack(directions _directions)
     {


### PR DESCRIPTION
Inhalt von OnDestroy() in Hazardnut/CommonKnughtDeath() verschoben.
In DamageHandler wird bei Health unter 0 die entsprechende Funktion aufgerufen.