### PR TITLE
NUT-243 Dash Bugfixing

### DIFF
--- a/NutMyProblemUnity/Assets/Resources/prefabs/Level/Drawbridge.prefab
+++ b/NutMyProblemUnity/Assets/Resources/prefabs/Level/Drawbridge.prefab
@@ -43,7 +43,7 @@ BoxCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7319751005854133280}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0

--- a/NutMyProblemUnity/Assets/Scripts/playerController.cs
+++ b/NutMyProblemUnity/Assets/Scripts/playerController.cs
@@ -30,6 +30,7 @@ public class playerController : MonoBehaviour
     float defaultGravity;
     float dashGravity = 1;
     bool isDashing;
+    bool hasDash;
 
     public bool isGrounded;
     bool leftRay;
@@ -71,6 +72,8 @@ public class playerController : MonoBehaviour
 
     private void Update()
     {
+        if (isGrounded) hasDash = true;
+
         MovePlayer();
         UpdateShadow();
         MoveDeathBarrier();
@@ -225,10 +228,14 @@ public class playerController : MonoBehaviour
             rb.AddForce(new Vector2(1000, 0) * moveDir);
             rb.velocity = new Vector2(rb.velocity.x, 0);
         }
+
+        if (!isGrounded) hasDash = false;
     }
 
     public bool IsDashAvailable()
     {
+        if(!hasDash) return false;
+        if(moveDir == 0) return false;
         return Time.time > lastDashTime + fDashCooldown;
     }
 


### PR DESCRIPTION
-Fixed bug where players could dash more than once while airborne
-Fixed bug where players could hover by not moving left or right when dashing
-Fixed drawbridge being lowered as default